### PR TITLE
added comparision between the types of Array in java

### DIFF
--- a/translations/Portuguese_Java.csv
+++ b/translations/Portuguese_Java.csv
@@ -25,7 +25,8 @@ booleano,boolean
 duplo,double
 longo,long
 extenso,long
-vetor,Array
+vetor,Single Dimensional Array
+matriz,Multidimensional Array
 lista,List
 curto,short
 pequeno,short


### PR DESCRIPTION
There's two types of arrays in java. The single Dimensional one and the multidimensional, which would make a difference when translating from array. An array can be a "vector" or a "matriz". It depends if its a single dimension or multidimensional.

Select any of the following which apply to your changes:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

Summarize your changes, including issues addressed:

Describe how you tested your changes:

### Checklist:

- [ ] I have commented throughout my code
- [ ] I have tested my code
- [ ] I have modified the documentation, if necessary
- [ ] I have modified information regarding dependencies, if necessary
